### PR TITLE
月別使用量取得API

### DIFF
--- a/api.go
+++ b/api.go
@@ -26,4 +26,5 @@ type API interface {
 	DeleteCertificate(ctx context.Context, id string) error
 	DeleteAllCache(ctx context.Context, param *DeleteAllCacheRequest) error
 	DeleteCache(ctx context.Context, param *DeleteCacheRequest) ([]*DeleteCacheResult, error)
+	MonthlyUsage(ctx context.Context, targetYM string) (*MonthlyUsageResults, error)
 }

--- a/monthly_usage.go
+++ b/monthly_usage.go
@@ -1,0 +1,37 @@
+// Copyright 2022 The webaccel-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webaccel
+
+import "encoding/json"
+
+// MonthlyUsageResults 月別使用量
+type MonthlyUsageResults struct {
+	Year          int
+	Month         int
+	MonthlyUsages []*MonthlyUsage
+}
+
+type MonthlyUsage struct {
+	SiteID             json.Number
+	Domain             string
+	ASCIIDomain        string
+	Subdomain          string
+	AccessCount        int64
+	BytesSent          int64
+	CacheMissBytesSent int64
+	CacheHitRatio      float64
+	BytesCacheHitRatio float64
+	Price              int64
+}

--- a/op.go
+++ b/op.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 )
 
 type APICaller interface {
@@ -211,4 +212,29 @@ func (o *Op) DeleteCache(ctx context.Context, param *DeleteCacheRequest) ([]*Del
 		return nil, err
 	}
 	return results.Results, nil
+}
+
+// MonthlyUsage クラウドアカウントに登録されている全サイトの月別使用量を取得する。
+//
+// targetフィールドの値は「yyyymm」形式で対象年月を指定する。
+// (例: 2021年02月の場合は、「202102」と指定。)
+// 指定がない場合は、今月の月別使用量を取得する。
+func (o *Op) MonthlyUsage(ctx context.Context, targetYM string) (*MonthlyUsageResults, error) {
+	params := url.Values{
+		"target": {targetYM},
+	}
+	url := o.Client.RootURL() + "monthlyusage?" + params.Encode()
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	var results MonthlyUsageResults
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, err
+	}
+	return &results, nil
 }

--- a/op_test.go
+++ b/op_test.go
@@ -149,3 +149,15 @@ func TestOp_DeleteCache(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
 }
+
+func TestOp_MonthlyUsage(t *testing.T) {
+	checkEnv(t)
+
+	client := testClient()
+	results, err := client.MonthlyUsage(context.Background(), "")
+
+	require.NoError(t, err)
+	require.NotEmpty(t, results.Year)
+	require.NotEmpty(t, results.Month)
+	require.NotEmpty(t, results.MonthlyUsages)
+}


### PR DESCRIPTION
closes #8 

Note: SiteIDはドキュメント上は文字列になっているが、実際には数値が返ってくる。
今回は参照のみの項目であることから`json.Number`を利用したが、今後類似の項目が出てくる場合は別途対応を検討する。