### PR TITLE
サイト更新API

### DIFF
--- a/api.go
+++ b/api.go
@@ -20,6 +20,7 @@ import "context"
 type API interface {
 	List(ctx context.Context) (*ListSitesResult, error)
 	Read(ctx context.Context, id string) (*Site, error)
+	Update(ctx context.Context, id string, param *UpdateSiteRequest) (*Site, error)
 	ReadCertificate(ctx context.Context, id string) (*Certificates, error)
 	CreateCertificate(ctx context.Context, id string, param *CreateOrUpdateCertificateRequest) (*Certificates, error)
 	UpdateCertificate(ctx context.Context, id string, param *CreateOrUpdateCertificateRequest) (*Certificates, error)

--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,46 @@
+// Copyright 2022 The webaccel-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webaccel
+
+// OriginType
+const (
+	OriginTypesWebServer     = "0" // ウェブサーバ
+	OriginTypesObjectStorage = "1" // オブジェクトストレージ
+)
+
+// RequestProtocol
+const (
+	RequestProtocolsHttpAndHttps    = "0" // http/https
+	RequestProtocolsHttpsOnly       = "1" // httpsのみ
+	RequestProtocolsRedirectToHttps = "2" // httpsに」リダイレクト
+)
+
+// OriginProtocol
+const (
+	OriginProtocolsHttp  = "http"
+	OriginProtocolsHttps = "https"
+)
+
+// VarySupport
+const (
+	VarySupportDisabled = "0" // 無効
+	VarySupportEnabled  = "1" // 有効
+)
+
+// DocIndex
+const (
+	DocIndexDisabled = "0" // 無効
+	DocIndexEnabled  = "1" // 有効
+)

--- a/op.go
+++ b/op.go
@@ -85,6 +85,33 @@ func (o *Op) Read(ctx context.Context, id string) (*Site, error) {
 	return results.Site, nil
 }
 
+// Update サイト更新
+func (o *Op) Update(ctx context.Context, id string, param *UpdateSiteRequest) (*Site, error) {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s", id)
+
+	// build request body
+	type updateRequest struct {
+		Site *UpdateSiteRequest
+	}
+	body := &updateRequest{Site: param}
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	type updateResult struct {
+		Site *Site
+	}
+	var results updateResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, err
+	}
+	return results.Site, nil
+}
+
 // ReadCertificate サイト証明書の参照
 func (o *Op) ReadCertificate(ctx context.Context, id string) (*Certificates, error) {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/certificate", id)

--- a/op_test.go
+++ b/op_test.go
@@ -77,6 +77,22 @@ func TestOp_Read(t *testing.T) {
 	require.Equal(t, read.ID, siteId)
 }
 
+func TestOp_Update(t *testing.T) {
+	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
+
+	client := testClient()
+	siteId := os.Getenv("SAKURACLOUD_WEBACCEL_SITE_ID")
+	name := testutil.RandomName("webaccel-api-go-test-", 8, testutil.CharSetAlpha)
+	updated, err := client.Update(context.Background(), siteId, &webaccel.UpdateSiteRequest{
+		Name:        name,
+		VarySupport: webaccel.VarySupportDisabled,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, updated.Name, name)
+	require.Equal(t, updated.VarySupport, webaccel.VarySupportEnabled)
+}
+
 func TestWebAccelOp_Cert(t *testing.T) {
 	envKeys := []string{
 		"SAKURACLOUD_WEBACCEL_SITE_ID",

--- a/parameter.go
+++ b/parameter.go
@@ -45,3 +45,30 @@ type CreateOrUpdateCertificateRequest struct {
 	CertificateChain string
 	Key              string
 }
+
+// UpdateSiteRequest サイト更新リクエスト
+type UpdateSiteRequest struct {
+	// 「オリジン種別」に関係なく設定できる共通項目
+	Name            string `json:",omitempty"`
+	OriginType      string `json:",omitempty" validate:"omitempty,oneof=0 1"`   // 0:ウェブサーバ, 1:オブジェクトストレージ
+	RequestProtocol string `json:",omitempty" validate:"omitempty,oneof=0 1 2"` // 0:http/https, 1:httpsのみ, 2:httpsにリダイレクト
+	OriginProtocol  string `json:",omitempty" validate:"omitempty,oneof=http https"`
+	DefaultCacheTTL int    `json:",omitempty" validate:"omitempty,min=-1,max=604800"` // -1:無効, 0 ～ 604800 の範囲内の数値: デフォルトのキャッシュ期間(秒)
+	VarySupport     string `json:",omitempty" validate:"omitempty,oneof=0 1"`         // 0:無効, 1:有効
+
+	// CORSRules ルール一覧、設定されている場合単一要素を持つ配列となる
+	CORSRules         []*CORSRule `json:",omitempty"`
+	OnetimeURLSecrets []string    `json:",omitempty"`
+
+	// 「オリジン種別」が「ウェブサーバ」の場合に設定可能な項目
+	Origin     string `json:",omitempty"`
+	HostHeader string `json:",omitempty"`
+
+	// 「オリジン種別」が「オブジェクトストレージ」の場合に設定可能な項目
+	BucketName      string `json:",omitempty"`
+	S3Endpoint      string `json:",omitempty"`
+	S3Region        string `json:",omitempty"`
+	DocIndex        string `json:",omitempty" validate:"omitempty,oneof=0 1"` // 0:無効, 1:有効
+	AccessKeyID     string `json:",omitempty"`
+	SecretAccessKey string `json:",omitempty"`
+}


### PR DESCRIPTION
サイト更新API( https://manual.sakura.ad.jp/cloud/webaccel/api.html#id26 )に対応する。

```go
	// 利用例
	updated, err := client.Update(context.Background(), siteId, &webaccel.UpdateSiteRequest{
		Name:        name,
		VarySupport: webaccel.VarySupportDisabled,
	})
```

Note: 更新パラメータとして"0"や"1"を受け取るパラメータが多数ある。  
enumにしてもよかったが、なるべく独自の型を作りたくなかったため、constとして各種パラメータの候補値を定義しておく方法を採用した。

定義の例: 
```go
// OriginType
const (
	OriginTypesWebServer     = "0" // ウェブサーバ
	OriginTypesObjectStorage = "1" // オブジェクトストレージ
)

// RequestProtocol
const (
	RequestProtocolsHttpAndHttps    = "0" // http/https
	RequestProtocolsHttpsOnly       = "1" // httpsのみ
	RequestProtocolsRedirectToHttps = "2" // httpsに」リダイレクト
)
```