### PR TITLE
ACL機能

### DIFF
--- a/api.go
+++ b/api.go
@@ -21,6 +21,9 @@ type API interface {
 	List(ctx context.Context) (*ListSitesResult, error)
 	Read(ctx context.Context, id string) (*Site, error)
 	Update(ctx context.Context, id string, param *UpdateSiteRequest) (*Site, error)
+	ReadACL(ctx context.Context, id string) (*ACLResult, error)
+	UpsertACL(ctx context.Context, id string, acl string) (*ACLResult, error)
+	DeleteACL(ctx context.Context, id string) error
 	ReadCertificate(ctx context.Context, id string) (*Certificates, error)
 	CreateCertificate(ctx context.Context, id string, param *CreateOrUpdateCertificateRequest) (*Certificates, error)
 	UpdateCertificate(ctx context.Context, id string, param *CreateOrUpdateCertificateRequest) (*Certificates, error)

--- a/op.go
+++ b/op.go
@@ -112,6 +112,63 @@ func (o *Op) Update(ctx context.Context, id string, param *UpdateSiteRequest) (*
 	return results.Site, nil
 }
 
+// ReadACL サイトのACL取得
+func (o *Op) ReadACL(ctx context.Context, id string) (*ACLResult, error) {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/acl", id)
+
+	// build request body
+	var body interface{}
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	var result ACLResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpsertACL サイトのACLの登録/更新
+func (o *Op) UpsertACL(ctx context.Context, id string, acl string) (*ACLResult, error) {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/acl", id)
+
+	// build request body
+	type upsertACLRequest struct {
+		ACL string `validate:"required"`
+	}
+	body := &upsertACLRequest{ACL: acl}
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	var result ACLResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteACL サイトのACLの削除
+func (o *Op) DeleteACL(ctx context.Context, id string) error {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/acl", id)
+
+	// build request body
+	var body interface{}
+
+	// do request
+	_, err := o.Client.Do(ctx, "DELETE", url, body)
+	return err
+}
+
 // ReadCertificate サイト証明書の参照
 func (o *Op) ReadCertificate(ctx context.Context, id string) (*Certificates, error) {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/certificate", id)

--- a/parameter.go
+++ b/parameter.go
@@ -72,3 +72,7 @@ type UpdateSiteRequest struct {
 	AccessKeyID     string `json:",omitempty"`
 	SecretAccessKey string `json:",omitempty"`
 }
+
+type ACLResult struct {
+	ACL string
+}


### PR DESCRIPTION
ACL機能に対応

APIドキュメント: https://manual.sakura.ad.jp/cloud/webaccel/api.html#id35

追加されるAPI:

```
	ReadACL(ctx context.Context, id string) (*ACLResult, error)
	UpsertACL(ctx context.Context, id string, acl string) (*ACLResult, error)
	DeleteACL(ctx context.Context, id string) error
```

テスト結果
```
--- PASS: TestWebAccelOp_ACL (0.93s)
    --- PASS: TestWebAccelOp_ACL/create_ACL (0.30s)
    --- PASS: TestWebAccelOp_ACL/read_ACL (0.10s)
    --- PASS: TestWebAccelOp_ACL/update_ACL (0.17s)
    --- PASS: TestWebAccelOp_ACL/delete_ACL (0.35s)
PASS
ok  	github.com/sacloud/webaccel-api-go	1.301s

```