### PR TITLE
goreleaser v2に対応

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
-build:
-  skip: true
+version: 2
+builds:
+  - skip: true
 release:
   draft: false
 changelog:
-  skip: false
+  disable: false


### PR DESCRIPTION
https://github.com/sacloud/webaccel-api-go/pull/55 によりgoreleaser v2が使われるようになったため関連する設定項目を修正する

類似PR: https://github.com/sacloud/apprun-api-go/pull/19

ついでにGoのバージョン指定に `go-version-file: 'go.mod'`を使うように修正しておく。