### PR TITLE
ウェブアクセラレーターの作成・削除・有効化/無効化機能をサポート

### DIFF
--- a/api.go
+++ b/api.go
@@ -19,8 +19,10 @@ import "context"
 // API is interface for operate WebAccel resource
 type API interface {
 	List(ctx context.Context) (*ListSitesResult, error)
+	Create(ctx context.Context, param *CreateSiteRequest) (*Site, error)
 	Read(ctx context.Context, id string) (*Site, error)
 	Update(ctx context.Context, id string, param *UpdateSiteRequest) (*Site, error)
+	UpdateStatus(ctx context.Context, id string, param *UpdateSiteStatusRequest) (*Site, error)
 	ReadACL(ctx context.Context, id string) (*ACLResult, error)
 	UpsertACL(ctx context.Context, id string, acl string) (*ACLResult, error)
 	DeleteACL(ctx context.Context, id string) error
@@ -30,5 +32,6 @@ type API interface {
 	DeleteCertificate(ctx context.Context, id string) error
 	DeleteAllCache(ctx context.Context, param *DeleteAllCacheRequest) error
 	DeleteCache(ctx context.Context, param *DeleteCacheRequest) ([]*DeleteCacheResult, error)
+	Delete(ctx context.Context, id string) (*Site, error)
 	MonthlyUsage(ctx context.Context, targetYM string) (*MonthlyUsageResults, error)
 }

--- a/op.go
+++ b/op.go
@@ -38,6 +38,35 @@ func NewOp(caller APICaller) API {
 	return &Op{Client: caller}
 }
 
+// Create 新規サイトの作成
+//
+// NOTE: undocumented resource
+func (o *Op) Create(ctx context.Context, param *CreateSiteRequest) (*Site, error) {
+	url := o.Client.RootURL() + "site"
+
+	// build request body
+	type createRequest struct {
+		Site *CreateSiteRequest
+	}
+	body := &createRequest{Site: param}
+
+	// do request
+	data, err := o.Client.Do(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	type createResult struct {
+		Site *Site
+	}
+	var results createResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, err
+	}
+	return results.Site, nil
+}
+
 // List サイト一覧
 //
 // NOTE: 各サイトのCORSRulesはnullになる点に注意
@@ -106,6 +135,36 @@ func (o *Op) Update(ctx context.Context, id string, param *UpdateSiteRequest) (*
 		Site *Site
 	}
 	var results updateResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, err
+	}
+	return results.Site, nil
+}
+
+// UpdateStatus サイト有効化状態の更新
+//
+// NOTE: undocumented resource
+func (o *Op) UpdateStatus(ctx context.Context, id string, param *UpdateSiteStatusRequest) (*Site, error) {
+
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/status", id)
+
+	// build request body
+	type updateStatusRequest struct {
+		Site *UpdateSiteStatusRequest
+	}
+	body := &updateStatusRequest{Site: param}
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	type updateStatusResult struct {
+		Site *Site
+	}
+	var results updateStatusResult
 	if err := json.Unmarshal(data, &results); err != nil {
 		return nil, err
 	}
@@ -321,4 +380,30 @@ func (o *Op) MonthlyUsage(ctx context.Context, targetYM string) (*MonthlyUsageRe
 		return nil, err
 	}
 	return &results, nil
+}
+
+// Delete サイト削除
+//
+// NOTE: undocumented resource
+func (o *Op) Delete(ctx context.Context, id string) (*Site, error) {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s", id)
+
+	// build request body
+	var body interface{}
+
+	// do request
+	data, err := o.Client.Do(ctx, "DELETE", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	type deleteResults struct {
+		Site *Site
+	}
+	var results deleteResults
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, err
+	}
+	return results.Site, nil
 }

--- a/parameter.go
+++ b/parameter.go
@@ -46,6 +46,35 @@ type CreateOrUpdateCertificateRequest struct {
 	Key              string
 }
 
+// CreateSiteRequest サイト作成リクエスト
+type CreateSiteRequest struct {
+	// 「オリジン種別」に関係なく設定できる共通項目
+	Name            string `json:",omitempty"`
+	OriginType      string `json:",omitempty" validate:"omitempty,oneof=0 1"` // 0:ウェブサーバ, 1:オブジェクトストレージ
+	ASCIIDomain     string `json:",omitempty" validate:"omitempty"`           // 独自ドメインを設定する場合のみ
+	DomainType      string `json:",omitempty" validate:"omitempty,oneof=own_domain subdomain"`
+	RequestProtocol string `json:",omitempty" validate:"omitempty,oneof=0 1 2"` // 0:http/https, 1:httpsのみ, 2:httpsにリダイレクト
+	OriginProtocol  string `json:",omitempty" validate:"omitempty,oneof=http https"`
+	DefaultCacheTTL *int   `json:",omitempty" validate:"omitempty,min=-1,max=604800"` // -1:無効, 0 ～ 604800 の範囲内の数値: デフォルトのキャッシュ期間(秒)
+	VarySupport     string `json:",omitempty" validate:"omitempty,oneof=0 1"`         // 0:無効, 1:有効
+
+	// CORSRules ルール一覧、設定されている場合単一要素を持つ配列となる
+	CORSRules         *[]*CORSRule `json:",omitempty"`
+	OnetimeURLSecrets *[]string    `json:",omitempty"`
+
+	// 「オリジン種別」が「ウェブサーバ」の場合に設定可能な項目
+	Origin     string `json:",omitempty"`
+	HostHeader string `json:",omitempty"`
+
+	// 「オリジン種別」が「オブジェクトストレージ」の場合に設定可能な項目
+	BucketName      string `json:",omitempty"`
+	S3Endpoint      string `json:",omitempty"`
+	S3Region        string `json:",omitempty"`
+	DocIndex        string `json:",omitempty" validate:"omitempty,oneof=0 1"` // 0:無効, 1:有効
+	AccessKeyID     string `json:",omitempty"`
+	SecretAccessKey string `json:",omitempty"`
+}
+
 // UpdateSiteRequest サイト更新リクエスト
 type UpdateSiteRequest struct {
 	// 「オリジン種別」に関係なく設定できる共通項目
@@ -71,6 +100,11 @@ type UpdateSiteRequest struct {
 	DocIndex        string `json:",omitempty" validate:"omitempty,oneof=0 1"` // 0:無効, 1:有効
 	AccessKeyID     string `json:",omitempty"`
 	SecretAccessKey string `json:",omitempty"`
+}
+
+// UpdateSiteStatusRequest サイトの有効化状態更新リクエスト
+type UpdateSiteStatusRequest struct {
+	Status string `validate:"oneof=enabled disabled"`
 }
 
 type ACLResult struct {

--- a/parameter.go
+++ b/parameter.go
@@ -51,7 +51,7 @@ type CreateSiteRequest struct {
 	// 「オリジン種別」に関係なく設定できる共通項目
 	Name            string `json:",omitempty"`
 	OriginType      string `json:",omitempty" validate:"omitempty,oneof=0 1"` // 0:ウェブサーバ, 1:オブジェクトストレージ
-	ASCIIDomain     string `json:",omitempty" validate:"omitempty"`           // 独自ドメインを設定する場合のみ
+	Domain     string `json:",omitempty" validate:"omitempty"`           // 独自ドメインを設定する場合のみ
 	DomainType      string `json:",omitempty" validate:"omitempty,oneof=own_domain subdomain"`
 	RequestProtocol string `json:",omitempty" validate:"omitempty,oneof=0 1 2"` // 0:http/https, 1:httpsのみ, 2:httpsにリダイレクト
 	OriginProtocol  string `json:",omitempty" validate:"omitempty,oneof=http https"`


### PR DESCRIPTION
## 概要

このPRでは以下のundocumentedな機能のサポートを追加します。

* サイトの新規作成
* サイトの有効化・無効化
* サイトの削除

4月22日現在、公式ドキュメントにはこれらの機能は記載されていませんが、いずれの操作もAPI経由で実施できることを確認しました。

## このPRが実現すること

[webaccel-api-go](https://github.com/sacloud/webaccel-api-go)ライブラリを通じたサイトの作成・削除を可能とします。
将来的には[Terraformプロバイダー](https://github.com/sacloud/terraform-provider-sakuracloud)
による完全なウェブアクセラレーターの制御が可能となります。

## 備考

テストケースでは、既存の環境変数を汚染しない形で、新規サイトの作成・削除処理を検証しています。