### PR TITLE
オリジンガードトークン、Let's Encrypt、Brotli圧縮、ログ設定のサポートを追加

### DIFF
--- a/api.go
+++ b/api.go
@@ -24,7 +24,6 @@ type API interface {
 	Update(ctx context.Context, id string, param *UpdateSiteRequest) (*Site, error)
 	UpdateStatus(ctx context.Context, id string, param *UpdateSiteStatusRequest) (*Site, error)
 	CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error)
-	ReadOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error)
 	DeleteOriginGuardToken(ctx context.Context, id string) error
 	CreateNextOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error)
 	DeleteNextOriginGuardToken(ctx context.Context, id string) error

--- a/api.go
+++ b/api.go
@@ -23,6 +23,10 @@ type API interface {
 	Read(ctx context.Context, id string) (*Site, error)
 	Update(ctx context.Context, id string, param *UpdateSiteRequest) (*Site, error)
 	UpdateStatus(ctx context.Context, id string, param *UpdateSiteStatusRequest) (*Site, error)
+	CreateOriginGuardToken(ctx context.Context, id string) (*CreateOriginGuardTokenResult, error)
+	CreateNextOriginGuardToken(ctx context.Context, id string) (*CreateOriginGuardTokenResult, error)
+	CreateAutoCertUpdate(ctx context.Context, id string) error
+	DeleteAutoCertUpdate(ctx context.Context, id string) error
 	ReadACL(ctx context.Context, id string) (*ACLResult, error)
 	UpsertACL(ctx context.Context, id string, acl string) (*ACLResult, error)
 	DeleteACL(ctx context.Context, id string) error

--- a/api.go
+++ b/api.go
@@ -23,8 +23,11 @@ type API interface {
 	Read(ctx context.Context, id string) (*Site, error)
 	Update(ctx context.Context, id string, param *UpdateSiteRequest) (*Site, error)
 	UpdateStatus(ctx context.Context, id string, param *UpdateSiteStatusRequest) (*Site, error)
-	CreateOriginGuardToken(ctx context.Context, id string) (*CreateOriginGuardTokenResult, error)
-	CreateNextOriginGuardToken(ctx context.Context, id string) (*CreateOriginGuardTokenResult, error)
+	CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResult, error)
+	ReadOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResult, error)
+	DeleteOriginGuardToken(ctx context.Context, id string) error
+	CreateNextOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResult, error)
+	DeleteNextOriginGuardToken(ctx context.Context, id string) error
 	CreateAutoCertUpdate(ctx context.Context, id string) error
 	DeleteAutoCertUpdate(ctx context.Context, id string) error
 	ReadACL(ctx context.Context, id string) (*ACLResult, error)

--- a/api.go
+++ b/api.go
@@ -23,10 +23,10 @@ type API interface {
 	Read(ctx context.Context, id string) (*Site, error)
 	Update(ctx context.Context, id string, param *UpdateSiteRequest) (*Site, error)
 	UpdateStatus(ctx context.Context, id string, param *UpdateSiteStatusRequest) (*Site, error)
-	CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResult, error)
-	ReadOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResult, error)
+	CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error)
+	ReadOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error)
 	DeleteOriginGuardToken(ctx context.Context, id string) error
-	CreateNextOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResult, error)
+	CreateNextOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error)
 	DeleteNextOriginGuardToken(ctx context.Context, id string) error
 	CreateAutoCertUpdate(ctx context.Context, id string) error
 	DeleteAutoCertUpdate(ctx context.Context, id string) error
@@ -41,4 +41,7 @@ type API interface {
 	DeleteCache(ctx context.Context, param *DeleteCacheRequest) ([]*DeleteCacheResult, error)
 	Delete(ctx context.Context, id string) (*Site, error)
 	MonthlyUsage(ctx context.Context, targetYM string) (*MonthlyUsageResults, error)
+	ApplyLogUploadConfig(ctx context.Context, id string, param *LogUploadConfig) (*LogUploadConfig, error)
+	ReadLogUploadConfig(ctx context.Context, id string) (*LogUploadConfig, error)
+	DeleteLogUploadConfig(ctx context.Context, id string) error
 }

--- a/constants.go
+++ b/constants.go
@@ -44,3 +44,9 @@ const (
 	DocIndexDisabled = "0" // 無効
 	DocIndexEnabled  = "1" // 有効
 )
+
+// NormalizeAE
+const (
+	NormalizeAEGz   = "1" // gzipに正規化
+	NormalizeAEBzGz = "3" // bzとgzipの組に正規化
+)

--- a/constants.go
+++ b/constants.go
@@ -48,5 +48,5 @@ const (
 // NormalizeAE
 const (
 	NormalizeAEGz   = "1" // gzipに正規化
-	NormalizeAEBzGz = "3" // bzとgzipの組に正規化
+	NormalizeAEBrGz = "3" // brとgzipの組に正規化
 )

--- a/log_upload_config.go
+++ b/log_upload_config.go
@@ -2,10 +2,10 @@ package webaccel
 
 // LogUploadConfig ログアップロード設定
 type LogUploadConfig struct {
-	Bucket          string `json:",omitempty"`
-	Endpoint        string `json:",omitempty" validate:"omitempty,equal=https://s3.isk01.sakurastorage.jp"`
-	Region          string `json:",omitempty" validate:"omitempty,equal=jp-north-1"`
-	AccessKeyID     string `json:",omitempty"`
-	SecretAccessKey string `json:",omitempty"`
-	Status          string `json:",omitempty" validate:"oneof=enabled disabled"`
+	Bucket          string `json:","`
+	Endpoint        string `json:"," validate:"omitempty,equal=https://s3.isk01.sakurastorage.jp"`
+	Region          string `json:"," validate:"omitempty,equal=jp-north-1"`
+	AccessKeyID     string `json:","`
+	SecretAccessKey string `json:","`
+	Status          string `json:"," validate:"oneof=enabled disabled"`
 }

--- a/log_upload_config.go
+++ b/log_upload_config.go
@@ -1,0 +1,11 @@
+package webaccel
+
+// LogUploadConfig ログアップロード設定
+type LogUploadConfig struct {
+	Bucket          string `json:",omitempty"`
+	Endpoint        string `json:",omitempty" validate:"omitempty,equal=https://s3.isk01.sakurastorage.jp"`
+	Region          string `json:",omitempty" validate:"omitempty,equal=jp-north-1"`
+	AccessKeyID     string `json:",omitempty"`
+	SecretAccessKey string `json:",omitempty"`
+	Status          string `json:",omitempty" validate:"oneof=enabled disabled"`
+}

--- a/log_upload_config.go
+++ b/log_upload_config.go
@@ -3,8 +3,8 @@ package webaccel
 // LogUploadConfig ログアップロード設定
 type LogUploadConfig struct {
 	Bucket          string `json:","`
-	Endpoint        string `json:"," validate:"omitempty,equal=https://s3.isk01.sakurastorage.jp"`
-	Region          string `json:"," validate:"omitempty,equal=jp-north-1"`
+	Endpoint        string `json:"," validate:",equal=https://s3.isk01.sakurastorage.jp"`
+	Region          string `json:"," validate:",equal=jp-north-1"`
 	AccessKeyID     string `json:","`
 	SecretAccessKey string `json:","`
 	Status          string `json:"," validate:"oneof=enabled disabled"`

--- a/op.go
+++ b/op.go
@@ -535,9 +535,6 @@ func (o *Op) ReadLogUploadConfig(ctx context.Context, id string) (*LogUploadConf
 	if err := json.Unmarshal(data, &result); err != nil {
 		return nil, err
 	}
-	if err := json.Unmarshal(data, &result); err != nil {
-		return nil, err
-	}
 	return result.SiteLogUploadConfig, nil
 }
 

--- a/op.go
+++ b/op.go
@@ -305,8 +305,7 @@ func (o *Op) UpdateCertificate(ctx context.Context, id string, param *CreateOrUp
 	return results.Certificate, nil
 }
 
-// CreateAutoCertUpdate Let's Encrypt による証明書自動更新を有効化
-// NOTE: undocumented operation
+// CreateAutoCertUpdate Let's Encrypt 自動更新証明書有効化
 func (o *Op) CreateAutoCertUpdate(ctx context.Context, id string) error {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/auto-cert-update", id)
 
@@ -321,8 +320,7 @@ func (o *Op) CreateAutoCertUpdate(ctx context.Context, id string) error {
 	return err
 }
 
-// DeleteAutoCertUpdate Let's Encrypt による証明書自動更新を無効化
-// NOTE: undocumented operation
+// DeleteAutoCertUpdate Let's Encrypt 自動更新証明書無効化
 func (o *Op) DeleteAutoCertUpdate(ctx context.Context, id string) error {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/auto-cert-update", id)
 
@@ -332,8 +330,7 @@ func (o *Op) DeleteAutoCertUpdate(ctx context.Context, id string) error {
 	return err
 }
 
-// CreateOriginGuardToken オリジンガードトークンの新規作成/ローテーション
-// NOTE: undocumented operation
+// CreateOriginGuardToken オリジンガードトークンの発行・更新
 func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error) {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token", id)
 
@@ -351,8 +348,7 @@ func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuar
 	return &results, nil
 }
 
-// CreateNextOriginGuardToken 次期オリジンガードトークンの作成
-// NOTE: undocumented operation
+// CreateNextOriginGuardToken オリジンガードトークンの次期トークン作成
 func (o *Op) CreateNextOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error) {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token/next", id)
 
@@ -371,7 +367,6 @@ func (o *Op) CreateNextOriginGuardToken(ctx context.Context, id string) (*Origin
 }
 
 // DeleteOriginGuardToken オリジンガードトークンの削除
-// NOTE: undocumented operation
 func (o *Op) DeleteOriginGuardToken(ctx context.Context, id string) error {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token", id)
 
@@ -384,8 +379,7 @@ func (o *Op) DeleteOriginGuardToken(ctx context.Context, id string) error {
 	return nil
 }
 
-// DeleteNextOriginGuardToken 次期オリジンガードトークンの削除
-// NOTE: undocumented operation
+// DeleteNextOriginGuardToken オリジンガードトークンの次期トークン更新キャンセル
 func (o *Op) DeleteNextOriginGuardToken(ctx context.Context, id string) error {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token/next", id)
 

--- a/op.go
+++ b/op.go
@@ -305,6 +305,71 @@ func (o *Op) UpdateCertificate(ctx context.Context, id string, param *CreateOrUp
 	return results.Certificate, nil
 }
 
+// CreateAutoCertUpdate Let's Encrypt による証明書自動更新を有効化
+// NOTE: undocumented resource
+func (o *Op) CreateAutoCertUpdate(ctx context.Context, id string) error {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/auto-cert-update", id)
+
+	// build request body
+	type autoCertUpdateRequest struct {
+		Type string
+	}
+	body := &autoCertUpdateRequest{Type: "letsencrypt"}
+
+	// do request
+	_, err := o.Client.Do(ctx, "POST", url, body)
+	return err
+}
+
+// DeleteAutoCertUpdate Let's Encrypt による証明書自動更新を無効化
+// NOTE: undocumented resource
+func (o *Op) DeleteAutoCertUpdate(ctx context.Context, id string) error {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/auto-cert-update", id)
+
+	// build request body
+	var body interface{}
+	_, err := o.Client.Do(ctx, "DELETE", url, body)
+	return err
+}
+
+// CreateOriginGuardToken オリジンガードトークンの新規作成/ローテーション
+// NOTE: undocumented resource
+func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*CreateOriginGuardTokenResult, error) {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token", id)
+
+	var body interface{}
+	// do request
+	data, err := o.Client.Do(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var results CreateOriginGuardTokenResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, err
+	}
+	return &results, nil
+}
+
+// CreateNextOriginGuardToken 次期オリジンガードトークンの作成
+// NOTE: undocumented resource
+func (o *Op) CreateNextOriginGuardToken(ctx context.Context, id string) (*CreateOriginGuardTokenResult, error) {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token/next", id)
+
+	var body interface{}
+	// do request
+	data, err := o.Client.Do(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var results CreateOriginGuardTokenResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, err
+	}
+	return &results, nil
+}
+
 // DeleteCertificate サイトの証明書を削除
 func (o *Op) DeleteCertificate(ctx context.Context, id string) error {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/certificate", id)

--- a/op.go
+++ b/op.go
@@ -306,7 +306,7 @@ func (o *Op) UpdateCertificate(ctx context.Context, id string, param *CreateOrUp
 }
 
 // CreateAutoCertUpdate Let's Encrypt による証明書自動更新を有効化
-// NOTE: undocumented resource
+// NOTE: undocumented operation
 func (o *Op) CreateAutoCertUpdate(ctx context.Context, id string) error {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/auto-cert-update", id)
 
@@ -322,7 +322,7 @@ func (o *Op) CreateAutoCertUpdate(ctx context.Context, id string) error {
 }
 
 // DeleteAutoCertUpdate Let's Encrypt による証明書自動更新を無効化
-// NOTE: undocumented resource
+// NOTE: undocumented operation
 func (o *Op) DeleteAutoCertUpdate(ctx context.Context, id string) error {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/auto-cert-update", id)
 
@@ -332,29 +332,8 @@ func (o *Op) DeleteAutoCertUpdate(ctx context.Context, id string) error {
 	return err
 }
 
-// ReadOriginGuardToken 設定済みのオリジンガードトークンを取得する
-// NOTE: undocumented resource
-func (o *Op) ReadOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error) {
-	url := o.Client.RootURL() + fmt.Sprintf("site/%s", id)
-
-	var body interface{}
-	// do request
-	data, err := o.Client.Do(ctx, "GET", url, body)
-	if err != nil {
-		return nil, err
-	}
-
-	var results struct {
-		Site OriginGuardTokenResponse
-	}
-	if err := json.Unmarshal(data, &results); err != nil {
-		return nil, err
-	}
-	return &results.Site, nil
-}
-
 // CreateOriginGuardToken オリジンガードトークンの新規作成/ローテーション
-// NOTE: undocumented resource
+// NOTE: undocumented operation
 func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error) {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token", id)
 
@@ -373,7 +352,7 @@ func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuar
 }
 
 // CreateNextOriginGuardToken 次期オリジンガードトークンの作成
-// NOTE: undocumented resource
+// NOTE: undocumented operation
 func (o *Op) CreateNextOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error) {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token/next", id)
 
@@ -392,7 +371,7 @@ func (o *Op) CreateNextOriginGuardToken(ctx context.Context, id string) (*Origin
 }
 
 // DeleteOriginGuardToken オリジンガードトークンの削除
-// NOTE: undocumented resource
+// NOTE: undocumented operation
 func (o *Op) DeleteOriginGuardToken(ctx context.Context, id string) error {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token", id)
 
@@ -406,7 +385,7 @@ func (o *Op) DeleteOriginGuardToken(ctx context.Context, id string) error {
 }
 
 // DeleteNextOriginGuardToken 次期オリジンガードトークンの削除
-// NOTE: undocumented resource
+// NOTE: undocumented operation
 func (o *Op) DeleteNextOriginGuardToken(ctx context.Context, id string) error {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token/next", id)
 

--- a/op.go
+++ b/op.go
@@ -332,9 +332,30 @@ func (o *Op) DeleteAutoCertUpdate(ctx context.Context, id string) error {
 	return err
 }
 
+// ReadOriginGuardToken 設定済みのオリジンガードトークンを取得する
+// NOTE: undocumented resource
+func (o *Op) ReadOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResult, error) {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s", id)
+
+	var body interface{}
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var results struct {
+		Site OriginGuardTokenResult
+	}
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, err
+	}
+	return &results.Site, nil
+}
+
 // CreateOriginGuardToken オリジンガードトークンの新規作成/ローテーション
 // NOTE: undocumented resource
-func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*CreateOriginGuardTokenResult, error) {
+func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResult, error) {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token", id)
 
 	var body interface{}
@@ -344,7 +365,7 @@ func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*CreateOrig
 		return nil, err
 	}
 
-	var results CreateOriginGuardTokenResult
+	var results OriginGuardTokenResult
 	if err := json.Unmarshal(data, &results); err != nil {
 		return nil, err
 	}
@@ -353,7 +374,7 @@ func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*CreateOrig
 
 // CreateNextOriginGuardToken 次期オリジンガードトークンの作成
 // NOTE: undocumented resource
-func (o *Op) CreateNextOriginGuardToken(ctx context.Context, id string) (*CreateOriginGuardTokenResult, error) {
+func (o *Op) CreateNextOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResult, error) {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token/next", id)
 
 	var body interface{}
@@ -363,11 +384,39 @@ func (o *Op) CreateNextOriginGuardToken(ctx context.Context, id string) (*Create
 		return nil, err
 	}
 
-	var results CreateOriginGuardTokenResult
+	var results OriginGuardTokenResult
 	if err := json.Unmarshal(data, &results); err != nil {
 		return nil, err
 	}
 	return &results, nil
+}
+
+// DeleteOriginGuardToken オリジンガードトークンの削除
+// NOTE: undocumented resource
+func (o *Op) DeleteOriginGuardToken(ctx context.Context, id string) error {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token", id)
+
+	var body interface{}
+	// do request
+	_, err := o.Client.Do(ctx, "DELETE", url, body)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteNextOriginGuardToken 次期オリジンガードトークンの削除
+// NOTE: undocumented resource
+func (o *Op) DeleteNextOriginGuardToken(ctx context.Context, id string) error {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token/next", id)
+
+	var body interface{}
+	// do request
+	_, err := o.Client.Do(ctx, "DELETE", url, body)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // DeleteCertificate サイトの証明書を削除

--- a/op.go
+++ b/op.go
@@ -334,7 +334,7 @@ func (o *Op) DeleteAutoCertUpdate(ctx context.Context, id string) error {
 
 // ReadOriginGuardToken 設定済みのオリジンガードトークンを取得する
 // NOTE: undocumented resource
-func (o *Op) ReadOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResult, error) {
+func (o *Op) ReadOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error) {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s", id)
 
 	var body interface{}
@@ -345,7 +345,7 @@ func (o *Op) ReadOriginGuardToken(ctx context.Context, id string) (*OriginGuardT
 	}
 
 	var results struct {
-		Site OriginGuardTokenResult
+		Site OriginGuardTokenResponse
 	}
 	if err := json.Unmarshal(data, &results); err != nil {
 		return nil, err
@@ -355,7 +355,7 @@ func (o *Op) ReadOriginGuardToken(ctx context.Context, id string) (*OriginGuardT
 
 // CreateOriginGuardToken オリジンガードトークンの新規作成/ローテーション
 // NOTE: undocumented resource
-func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResult, error) {
+func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error) {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token", id)
 
 	var body interface{}
@@ -365,7 +365,7 @@ func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuar
 		return nil, err
 	}
 
-	var results OriginGuardTokenResult
+	var results OriginGuardTokenResponse
 	if err := json.Unmarshal(data, &results); err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (o *Op) CreateOriginGuardToken(ctx context.Context, id string) (*OriginGuar
 
 // CreateNextOriginGuardToken 次期オリジンガードトークンの作成
 // NOTE: undocumented resource
-func (o *Op) CreateNextOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResult, error) {
+func (o *Op) CreateNextOriginGuardToken(ctx context.Context, id string) (*OriginGuardTokenResponse, error) {
 	url := o.Client.RootURL() + fmt.Sprintf("site/%s/origin-guard-token/next", id)
 
 	var body interface{}
@@ -384,7 +384,7 @@ func (o *Op) CreateNextOriginGuardToken(ctx context.Context, id string) (*Origin
 		return nil, err
 	}
 
-	var results OriginGuardTokenResult
+	var results OriginGuardTokenResponse
 	if err := json.Unmarshal(data, &results); err != nil {
 		return nil, err
 	}
@@ -514,4 +514,71 @@ func (o *Op) Delete(ctx context.Context, id string) (*Site, error) {
 		return nil, err
 	}
 	return results.Site, nil
+}
+
+// ApplyLogUploadConfig ログアップロード設定を作成・更新
+func (o *Op) ApplyLogUploadConfig(ctx context.Context, id string, param *LogUploadConfig) (*LogUploadConfig, error) {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/log-upload-config", id)
+
+	type applyLogUploadConfigRequest struct {
+		SiteLogUploadConfig *LogUploadConfig `json:",omitempty"`
+	}
+	req := applyLogUploadConfigRequest{
+		SiteLogUploadConfig: param,
+	}
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	type applyLogUploadConfigResponse applyLogUploadConfigRequest
+	var result applyLogUploadConfigResponse
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return result.SiteLogUploadConfig, nil
+}
+
+// ReadLogUploadConfig ログアップロードを取得
+func (o *Op) ReadLogUploadConfig(ctx context.Context, id string) (*LogUploadConfig, error) {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/log-upload-config", id)
+
+	var body interface{}
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	type ReadLogUploadConfigResponse struct {
+		SiteLogUploadConfig *LogUploadConfig `json:",omitempty"`
+	}
+
+	var result ReadLogUploadConfigResponse
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return result.SiteLogUploadConfig, nil
+}
+
+// DeleteLogUploadConfig ログアップロードを削除
+func (o *Op) DeleteLogUploadConfig(ctx context.Context, id string) error {
+	url := o.Client.RootURL() + fmt.Sprintf("site/%s/log-upload-config", id)
+
+	var body interface{}
+
+	// do request
+	_, err := o.Client.Do(ctx, "DELETE", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/op_test.go
+++ b/op_test.go
@@ -153,6 +153,31 @@ func TestOp_CreateOriginGuardToken(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, len(token.OriginGuardToken), 0)
 	require.Equal(t, len(token.NextOriginGuardToken), 0)
+}
+
+func TestOp_Senario_Create_DeleteOriginGuardToken(t *testing.T) {
+	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
+
+	client := testClient()
+	siteId := os.Getenv("SAKURACLOUD_WEBACCEL_SITE_ID")
+	token, err := client.CreateOriginGuardToken(context.Background(), siteId)
+	require.NoError(t, err)
+	require.NotEqual(t, len(token.OriginGuardToken), 0)
+	require.Equal(t, len(token.NextOriginGuardToken), 0)
+
+	err = client.DeleteOriginGuardToken(context.Background(), siteId)
+	require.NoError(t, err)
+}
+
+func TestOp_Senario_Create_CreateNextOriginGuardToken(t *testing.T) {
+	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
+
+	client := testClient()
+	siteId := os.Getenv("SAKURACLOUD_WEBACCEL_SITE_ID")
+	token, err := client.CreateOriginGuardToken(context.Background(), siteId)
+	require.NoError(t, err)
+	require.NotEqual(t, len(token.OriginGuardToken), 0)
+	require.Equal(t, len(token.NextOriginGuardToken), 0)
 
 	nexttoken, err := client.CreateNextOriginGuardToken(context.Background(), siteId)
 	require.NoError(t, err)
@@ -167,8 +192,43 @@ func TestOp_CreateOriginGuardToken(t *testing.T) {
 	require.Equal(t, len(token.NextOriginGuardToken), 0)
 }
 
-// NOTE: to avoid frakey test, two methods are tested here
-func TestOp_CreateAutoCertUpdate(t *testing.T) {
+func TestOp_Senario_Create_DeleteNextOriginGuardToken(t *testing.T) {
+	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
+
+	client := testClient()
+	siteId := os.Getenv("SAKURACLOUD_WEBACCEL_SITE_ID")
+	token, err := client.CreateOriginGuardToken(context.Background(), siteId)
+	require.NoError(t, err)
+	require.NotEqual(t, len(token.OriginGuardToken), 0)
+	require.Equal(t, len(token.NextOriginGuardToken), 0)
+
+	nexttoken, err := client.CreateNextOriginGuardToken(context.Background(), siteId)
+	require.NoError(t, err)
+	require.NotEqual(t, len(nexttoken.OriginGuardToken), 0)
+	require.NotEqual(t, len(nexttoken.NextOriginGuardToken), 0)
+	require.Equal(t, nexttoken.OriginGuardToken, token.OriginGuardToken)
+
+	err = client.DeleteNextOriginGuardToken(context.Background(), siteId)
+	require.NoError(t, err)
+}
+
+func TestOp_Senario_ReadOriginGuardToken(t *testing.T) {
+	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
+
+	client := testClient()
+	siteId := os.Getenv("SAKURACLOUD_WEBACCEL_SITE_ID")
+	token, err := client.CreateOriginGuardToken(context.Background(), siteId)
+	require.NoError(t, err)
+	require.NotEqual(t, len(token.OriginGuardToken), 0)
+	require.Equal(t, len(token.NextOriginGuardToken), 0)
+
+	res, err := client.ReadOriginGuardToken(context.Background(), siteId)
+	require.NoError(t, err)
+	require.NotEqual(t, len(res.OriginGuardToken), 0)
+	require.Equal(t, res.OriginGuardToken, token.OriginGuardToken)
+}
+
+func TestOp_Senario_Create_DeleteAutoCertUpdate(t *testing.T) {
 	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
 	client := testClient()
 	siteId := os.Getenv("SAKURACLOUD_WEBACCEL_SITE_ID")

--- a/op_test.go
+++ b/op_test.go
@@ -195,8 +195,7 @@ func TestOp_OriginGuardToken(t *testing.T) {
 
 }
 
-// NOTE: to avoid flakey test, two methods are tested here
-// NOTE: undocumented operation
+// NOTE: Let's Encrypt 自動更新が無効化されたサイトを用意しないと失敗する
 func TestOp_AutoCertUpdate(t *testing.T) {
 	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
 	client := testClient()
@@ -325,6 +324,7 @@ func TestOp_DeleteCache(t *testing.T) {
 	require.NotEmpty(t, result)
 }
 
+// NOTE: 当月中にトラフィックのないアカウントまたは月初のテストで失敗する
 func TestOp_MonthlyUsage(t *testing.T) {
 	checkEnv(t)
 

--- a/op_test.go
+++ b/op_test.go
@@ -67,6 +67,7 @@ func TestScenario_Op_Create_Enable_Disable_Delete(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, created.Name, name)
 	require.Equal(t, created.VarySupport, webaccel.VarySupportEnabled)
+	require.Equal(t, created.NormalizeAE, webaccel.NormalizeAEBzGz)
 	require.Equal(t, created.DefaultCacheTTL, 3600)
 	require.NotEmpty(t, created.ID)
 

--- a/op_test.go
+++ b/op_test.go
@@ -61,13 +61,13 @@ func TestScenario_Op_Create_Enable_Disable_Delete(t *testing.T) {
 		OriginProtocol:  webaccel.OriginProtocolsHttps,
 		VarySupport:     webaccel.VarySupportEnabled,
 		DefaultCacheTTL: pointer.NewInt(3600),
-		NormalizeAE:     webaccel.NormalizeAEBzGz,
+		NormalizeAE:     webaccel.NormalizeAEBrGz,
 	})
 
 	require.NoError(t, err)
 	require.Equal(t, created.Name, name)
 	require.Equal(t, created.VarySupport, webaccel.VarySupportEnabled)
-	require.Equal(t, created.NormalizeAE, webaccel.NormalizeAEBzGz)
+	require.Equal(t, created.NormalizeAE, webaccel.NormalizeAEBrGz)
 	require.Equal(t, created.DefaultCacheTTL, 3600)
 	require.NotEmpty(t, created.ID)
 

--- a/op_test.go
+++ b/op_test.go
@@ -62,6 +62,7 @@ func TestSenario_Op_Create_Enable_Disable_Delete(t *testing.T) {
 		OriginProtocol:  webaccel.OriginProtocolsHttps,
 		VarySupport:     webaccel.VarySupportEnabled,
 		DefaultCacheTTL: pointer.NewInt(3600),
+		NormalizeAE:     webaccel.NormalizeAEBzGz,
 	})
 
 	require.NoError(t, err)
@@ -133,6 +134,7 @@ func TestOp_Update(t *testing.T) {
 		CORSRules:         &[]*webaccel.CORSRule{},
 		OnetimeURLSecrets: &[]string{},
 		DefaultCacheTTL:   pointer.NewInt(0),
+		NormalizeAE:       webaccel.NormalizeAEGz,
 	})
 
 	require.NoError(t, err)

--- a/op_test.go
+++ b/op_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-
 	client "github.com/sacloud/api-client-go"
 	"github.com/sacloud/packages-go/pointer"
 	"github.com/sacloud/packages-go/testutil"
@@ -46,10 +45,10 @@ func testClient() webaccel.API {
 	})
 }
 
-// TestSenario_Op_Create_Enable_Disable_Delete
+// TestScenario_Op_Create_Enable_Disable_Delete
 // サイトの状態により実行結果が変化するメソッドのテストシナリオ
 // 実行順序: Create -> Enable -> Disable -> Delete
-func TestSenario_Op_Create_Enable_Disable_Delete(t *testing.T) {
+func TestScenario_Op_Create_Enable_Disable_Delete(t *testing.T) {
 	checkEnv(t)
 
 	client := testClient()
@@ -145,7 +144,6 @@ func TestOp_Update(t *testing.T) {
 	require.Equal(t, updated.DefaultCacheTTL, 0)
 }
 
-// NOTE: to avoid frakey test, two methods are tested here
 func TestOp_CreateOriginGuardToken(t *testing.T) {
 	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
 
@@ -157,7 +155,8 @@ func TestOp_CreateOriginGuardToken(t *testing.T) {
 	require.Equal(t, len(token.NextOriginGuardToken), 0)
 }
 
-func TestOp_Senario_Create_DeleteOriginGuardToken(t *testing.T) {
+// NOTE: to avoid flakey test, two methods are tested here
+func TestOp_Scenario_Create_DeleteOriginGuardToken(t *testing.T) {
 	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
 
 	client := testClient()
@@ -171,7 +170,7 @@ func TestOp_Senario_Create_DeleteOriginGuardToken(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestOp_Senario_Create_CreateNextOriginGuardToken(t *testing.T) {
+func TestOp_Scenario_Create_CreateNextOriginGuardToken(t *testing.T) {
 	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
 
 	client := testClient()
@@ -194,7 +193,7 @@ func TestOp_Senario_Create_CreateNextOriginGuardToken(t *testing.T) {
 	require.Equal(t, len(token.NextOriginGuardToken), 0)
 }
 
-func TestOp_Senario_Create_DeleteNextOriginGuardToken(t *testing.T) {
+func TestOp_Scenario_Create_DeleteNextOriginGuardToken(t *testing.T) {
 	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
 
 	client := testClient()
@@ -214,7 +213,7 @@ func TestOp_Senario_Create_DeleteNextOriginGuardToken(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestOp_Senario_ReadOriginGuardToken(t *testing.T) {
+func TestOp_Scenario_ReadOriginGuardToken(t *testing.T) {
 	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
 
 	client := testClient()
@@ -230,7 +229,7 @@ func TestOp_Senario_ReadOriginGuardToken(t *testing.T) {
 	require.Equal(t, res.OriginGuardToken, token.OriginGuardToken)
 }
 
-func TestOp_Senario_Create_DeleteAutoCertUpdate(t *testing.T) {
+func TestOp_Scenario_Create_DeleteAutoCertUpdate(t *testing.T) {
 	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
 	client := testClient()
 	siteId := os.Getenv("SAKURACLOUD_WEBACCEL_SITE_ID")
@@ -366,7 +365,7 @@ func TestOp_MonthlyUsage(t *testing.T) {
 	require.NotEmpty(t, results.MonthlyUsages)
 }
 
-func TestSenario_Op_Apply_ReadLogUploadConfig(t *testing.T) {
+func TestScenario_Op_Apply_ReadLogUploadConfig(t *testing.T) {
 	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
 	checkEnv(t, "SAKURASTORAGE_BUCKET_NAME")
 	checkEnv(t, "SAKURASTORAGE_ACCESS_KEY")

--- a/op_test.go
+++ b/op_test.go
@@ -365,3 +365,58 @@ func TestOp_MonthlyUsage(t *testing.T) {
 	require.NotEmpty(t, results.Month)
 	require.NotEmpty(t, results.MonthlyUsages)
 }
+
+func TestSenario_Op_Apply_ReadLogUploadConfig(t *testing.T) {
+	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
+	checkEnv(t, "SAKURASTORAGE_BUCKET_NAME")
+	checkEnv(t, "SAKURASTORAGE_ACCESS_KEY")
+	checkEnv(t, "SAKURASTORAGE_ACCESS_SECRET")
+
+	client := testClient()
+	siteId := os.Getenv("SAKURACLOUD_WEBACCEL_SITE_ID")
+	region := "jp-north-1"
+	endpoint := "https://s3.isk01.sakurastorage.jp"
+	bucketName := os.Getenv("SAKURASTORAGE_BUCKET_NAME")
+	accessKey := os.Getenv("SAKURASTORAGE_ACCESS_KEY")
+	accessSecret := os.Getenv("SAKURASTORAGE_ACCESS_SECRET")
+	status := "enabled"
+	require.NotEmpty(t, bucketName)
+	require.NotEmpty(t, accessKey)
+	require.NotEmpty(t, accessSecret)
+	applied, err := client.ApplyLogUploadConfig(context.Background(), siteId, &webaccel.LogUploadConfig{
+		Region:          region,
+		Endpoint:        endpoint,
+		Bucket:          bucketName,
+		AccessKeyID:     accessKey,
+		SecretAccessKey: accessSecret,
+		Status:          status,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, applied.Region, region)
+	require.Equal(t, applied.Endpoint, endpoint)
+	require.Equal(t, applied.Bucket, bucketName)
+	require.Equal(t, applied.AccessKeyID, accessKey)
+	require.Equal(t, applied.SecretAccessKey, accessSecret)
+	require.Equal(t, applied.Status, status)
+
+	read, err := client.ReadLogUploadConfig(context.Background(), siteId)
+
+	require.NoError(t, err)
+	require.Equal(t, read.Region, applied.Region)
+	require.Equal(t, read.Endpoint, applied.Endpoint)
+	require.Equal(t, read.Bucket, applied.Bucket)
+	require.NotEmpty(t, read.AccessKeyID)
+	require.NotEmpty(t, read.SecretAccessKey)
+	require.Equal(t, read.Status, applied.Status)
+}
+
+func TestOp_DeleteLogUploadConfig(t *testing.T) {
+	checkEnv(t, "SAKURACLOUD_WEBACCEL_SITE_ID")
+
+	client := testClient()
+	siteId := os.Getenv("SAKURACLOUD_WEBACCEL_SITE_ID")
+	err := client.DeleteLogUploadConfig(context.Background(), siteId)
+
+	require.NoError(t, err)
+}

--- a/parameter.go
+++ b/parameter.go
@@ -109,8 +109,8 @@ type ACLResult struct {
 	ACL string
 }
 
-// OriginGuardTokenResult サイトのオリジンガードトークン作成リクエスト
-type OriginGuardTokenResult struct {
+// OriginGuardTokenResponse サイトのオリジンガードトークン取得レスポンス
+type OriginGuardTokenResponse struct {
 	OriginGuardToken     string
 	NextOriginGuardToken string `json:",omitempty"`
 }

--- a/parameter.go
+++ b/parameter.go
@@ -111,6 +111,6 @@ type ACLResult struct {
 
 // OriginGuardTokenResponse サイトのオリジンガードトークン取得レスポンス
 type OriginGuardTokenResponse struct {
-	OriginGuardToken     string `json:",omitempty"`
-	NextOriginGuardToken string `json:",omitempty"`
+	OriginGuardToken     string `json:","`
+	NextOriginGuardToken string `json:","`
 }

--- a/parameter.go
+++ b/parameter.go
@@ -106,3 +106,9 @@ type UpdateSiteStatusRequest struct {
 type ACLResult struct {
 	ACL string
 }
+
+// CreateOriginGuardTokenResult サイトのオリジンガードトークン作成リクエスト
+type CreateOriginGuardTokenResult struct {
+	OriginGuardToken     string 
+	NextOriginGuardToken string `json:",omitempty"`
+}

--- a/parameter.go
+++ b/parameter.go
@@ -107,8 +107,8 @@ type ACLResult struct {
 	ACL string
 }
 
-// CreateOriginGuardTokenResult サイトのオリジンガードトークン作成リクエスト
-type CreateOriginGuardTokenResult struct {
-	OriginGuardToken     string 
+// OriginGuardTokenResult サイトのオリジンガードトークン作成リクエスト
+type OriginGuardTokenResult struct {
+	OriginGuardToken     string
 	NextOriginGuardToken string `json:",omitempty"`
 }

--- a/parameter.go
+++ b/parameter.go
@@ -57,6 +57,7 @@ type CreateSiteRequest struct {
 	OriginProtocol  string `json:",omitempty" validate:"omitempty,oneof=http https"`
 	DefaultCacheTTL *int   `json:",omitempty" validate:"omitempty,min=-1,max=604800"` // -1:無効, 0 ～ 604800 の範囲内の数値: デフォルトのキャッシュ期間(秒)
 	VarySupport     string `json:",omitempty" validate:"omitempty,oneof=0 1"`         // 0:無効, 1:有効
+	NormalizeAE     string `json:",omitempty" validate:"omitempty,oneof=1 3"`         // 1:Accept-Encodingをgzipに正規化, 3:bzとgzipの組に正規化
 
 	// 「オリジン種別」が「ウェブサーバ」の場合に設定可能な項目
 	Origin     string `json:",omitempty"`
@@ -80,6 +81,7 @@ type UpdateSiteRequest struct {
 	OriginProtocol  string `json:",omitempty" validate:"omitempty,oneof=http https"`
 	DefaultCacheTTL *int   `json:",omitempty" validate:"omitempty,min=-1,max=604800"` // -1:無効, 0 ～ 604800 の範囲内の数値: デフォルトのキャッシュ期間(秒)
 	VarySupport     string `json:",omitempty" validate:"omitempty,oneof=0 1"`         // 0:無効, 1:有効
+	NormalizeAE     string `json:",omitempty" validate:"omitempty,oneof=1 3"`         // 1:Accept-Encodingをgzipに正規化, 3:bzとgzipの組に正規化
 
 	// CORSRules ルール一覧、設定されている場合単一要素を持つ配列となる
 	CORSRules         *[]*CORSRule `json:",omitempty"`

--- a/parameter.go
+++ b/parameter.go
@@ -111,6 +111,6 @@ type ACLResult struct {
 
 // OriginGuardTokenResponse サイトのオリジンガードトークン取得レスポンス
 type OriginGuardTokenResponse struct {
-	OriginGuardToken     string
+	OriginGuardToken     string `json:",omitempty"`
 	NextOriginGuardToken string `json:",omitempty"`
 }

--- a/site.go
+++ b/site.go
@@ -28,11 +28,14 @@ type Site struct {
 	RequestProtocol string // 0:http/https, 1:httpsのみ, 2:httpsにリダイレクト
 	DefaultCacheTTL int    `validate:"min=-1,max=604800"` // -1:無効, 0 ～ 604800 の範囲内の数値: デフォルトのキャッシュ期間(秒)
 	VarySupport     string // 0:無効, 1:有効
+	NormalizeAE     string // 1:Accept-Encodingをgzipに正規化, 3:bzとgzipの組に正規化
 
-	OriginType     string // 0:ウェブサーバ, 1:オブジェクトストレージ
-	Origin         string
-	OriginProtocol string
-	HostHeader     string
+	OriginType           string // 0:ウェブサーバ, 1:オブジェクトストレージ
+	Origin               string
+	OriginProtocol       string
+	HostHeader           string
+	OriginGuardToken     string
+	NextOriginGuardToken string
 
 	// オブジェクトストレージをオリジンにする場合
 	BucketName string

--- a/site.go
+++ b/site.go
@@ -28,7 +28,8 @@ type Site struct {
 	RequestProtocol string // 0:http/https, 1:httpsのみ, 2:httpsにリダイレクト
 	DefaultCacheTTL int    `validate:"min=-1,max=604800"` // -1:無効, 0 ～ 604800 の範囲内の数値: デフォルトのキャッシュ期間(秒)
 	VarySupport     string // 0:無効, 1:有効
-	NormalizeAE     string // 1:Accept-Encodingをgzipに正規化, 3:bzとgzipの組に正規化
+	// NOTE: List()だと空、Read()でのみ参照可能
+	NormalizeAE string // 1:Accept-Encodingをgzipに正規化, 3:bzとgzipの組に正規化
 
 	OriginType           string // 0:ウェブサーバ, 1:オブジェクトストレージ
 	Origin               string


### PR DESCRIPTION
# 概要

このPRでは、[APIドキュメント](https://manual.sakura.ad.jp/cloud/webaccel/api.html)に記載のある操作のうち、このSDKで未実装となっていた以下の機能に対するサポートを追加します。

[操作]

* オリジンガードトークンの作成・削除
* オリジンガードトークンの次期トークン作成・トークン更新キャンセル
* Let's Encrypt自動更新証明書の有効化、自動更新無効化
* アクセスログアップロード設定の作成・更新、削除

[パラメタ]

* NormalizeAE (brotliないしはgzipによるAccept-Encoding正規化)

## テストの実行条件に関する備考

* Let's Encrypt設定については、事前に Let's Encryptが無効化されたサイトでテストする必要があります。
* NormalizeAEについては、パラメタの変更の挙動のみ検証しています。brotli配信を有効化したオリジンサーバーでの検証は未実施です。
* アクセスログアップロード設定については、他のテストと同様に環境変数経由でクレデンシャルを注入します。テスト用のバケットを作成した上で、テストランナーから以下の環境変数を参照する必要があります。
  - SAKURASTORAGE_BUCKET_NAME
  - SAKURASTORAGE_ACCESS_KEY
  - SAKURASTORAGE_ACCESS_SECRET

resolve #51 
