### PR TITLE
SDK利用者が各種パラメタを扱いやすくするconstと変換処理を追加

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -50,3 +50,37 @@ const (
 	NormalizeAEGz   = "1" // gzipに正規化
 	NormalizeAEBrGz = "3" // brとgzipの組に正規化
 )
+
+// 各種パラメタの文字列表現。
+// Note: APIリクエストそのものには指定できない。
+const (
+	gunzipCompressionNickname              = "gzip"
+	brotliCompressionNickname              = "br+gzip"
+	httpOrHttpsRequestProtocolNickname     = "http+https"
+	httpsOnlyRequestProtocolNickname       = "https"
+	httpsRedirectedRequestProtocolNickname = "https-redirect"
+)
+
+var (
+	// NormalizeAENicknameStrings
+	// NormalizeAEパラメタの文字列表現。APIリクエストには直接指定できないことに注意。
+	// MapNormalizeAENicknameToValue を用いてAPIリクエストに指定する値に変換できる。
+	NormalizeAENicknameStrings = []string{
+		gunzipCompressionNickname,
+		brotliCompressionNickname,
+	}
+	// RequestProtocolStrings
+	// RequestProtocolパラメタの文字列表現。APIリクエストには直接指定できないことに注意。
+	// MapRequestProtocolNicknameToValue を用いてAPIリクエストに指定する値に変換できる。
+	RequestProtocolStrings = []string{
+		httpOrHttpsRequestProtocolNickname,
+		httpsOnlyRequestProtocolNickname,
+		httpsRedirectedRequestProtocolNickname,
+	}
+	// OriginProtocolStrings
+	// OriginProtocolパラメタの文字列表現。いずれかの値をAPIリクエストに直接指定できる。
+	OriginProtocolStrings = []string{
+		OriginProtocolsHttp,
+		OriginProtocolsHttps,
+	}
+)

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,64 @@
+package webaccel
+
+import (
+	"fmt"
+)
+
+// MapRequestProtocolNicknameToValue maps non-origin request protocol nickname
+// (e.g. http+https) to a string const which is acceptable as a parameter of Site.
+func MapRequestProtocolNicknameToValue(protocolNickname string) (string, error) {
+	switch protocolNickname {
+	case httpOrHttpsRequestProtocolNickname:
+		return RequestProtocolsHttpAndHttps, nil
+	case httpsOnlyRequestProtocolNickname:
+		return RequestProtocolsHttpsOnly, nil
+	case httpsRedirectedRequestProtocolNickname:
+		return RequestProtocolsRedirectToHttps, nil
+	default:
+		return "", fmt.Errorf("invalid request protocol: %s", protocolNickname)
+	}
+}
+
+// MapRequestProtocolToNickname maps the site's (non-origin) request protocol value
+// (e.g. `1`) into human-readable string format such as `https`.
+func MapRequestProtocolToNickname(site *Site) (string, error) {
+	switch site.RequestProtocol {
+	case RequestProtocolsHttpAndHttps:
+		return httpOrHttpsRequestProtocolNickname, nil
+	case RequestProtocolsHttpsOnly:
+		return httpsOnlyRequestProtocolNickname, nil
+	case RequestProtocolsRedirectToHttps:
+		return httpsRedirectedRequestProtocolNickname, nil
+	default:
+		return "", fmt.Errorf("invalid request protocol: %s", site.RequestProtocol)
+	}
+}
+
+// MapNormalizeAENicknameToValue maps compression type nickname (e.g. br+gzip) to
+// string const which is acceptable as a parameter of Site.
+func MapNormalizeAENicknameToValue(compressionNickname string) (string, error) {
+	switch compressionNickname {
+	case gunzipCompressionNickname:
+		return NormalizeAEGz, nil
+	case brotliCompressionNickname:
+		return NormalizeAEBrGz, nil
+	}
+	return "", fmt.Errorf("invalid normalize_ae parameter: '%s'", compressionNickname)
+}
+
+// MapNormalizeAEValueToNickname maps the site's accept-encoding normalization parameter value
+// into human-readable  nickname such as `gzip`.
+func MapNormalizeAEValueToNickname(site *Site) (string, error) {
+	if site.NormalizeAE != "" {
+		if site.NormalizeAE == NormalizeAEBrGz {
+			return brotliCompressionNickname, nil
+		} else if site.NormalizeAE == NormalizeAEGz {
+			return gunzipCompressionNickname, nil
+		}
+		return "", fmt.Errorf("invalid normalize_ae parameter: '%s'", site.NormalizeAE)
+	}
+	//NOTE: APIが返却するデフォルト値は""。
+	// このフィールドでで "gzip" と "" が持つ効果は同一であるため、
+	// "gzip" として正規化する
+	return gunzipCompressionNickname, nil
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,107 @@
+package webaccel
+
+import (
+	"testing"
+)
+
+func TestMapRequestProtocolToNickname(t *testing.T) {
+	tt := []struct {
+		Name        string
+		Given       *Site
+		Want        string
+		ExpectError bool
+	}{
+		{
+			"valid http+https",
+			&Site{
+				RequestProtocol: RequestProtocolsHttpAndHttps,
+			},
+			httpOrHttpsRequestProtocolNickname,
+			false,
+		},
+		{
+			"valid https",
+			&Site{
+				RequestProtocol: RequestProtocolsHttpsOnly,
+			},
+			httpsOnlyRequestProtocolNickname,
+			false,
+		},
+		{
+			"valid https-redirect",
+			&Site{
+				RequestProtocol: RequestProtocolsRedirectToHttps,
+			},
+			httpsRedirectedRequestProtocolNickname,
+			false,
+		},
+		{
+			"invalid request protocol",
+			&Site{
+				RequestProtocol: "NO-SUCH-RP",
+			},
+			"",
+			true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			res, err := MapRequestProtocolToNickname(tc.Given)
+			if tc.ExpectError {
+				if err == nil {
+					t.Fatalf("expected error, got none")
+				}
+			} else if res != tc.Want {
+				t.Fatalf("FAILED %s: got: %v\nwant: %v", tc.Name, res, tc.Want)
+			}
+		})
+	}
+}
+
+func TestMapNormalizeAEValueToNickname(t *testing.T) {
+	tt := []struct {
+		Name        string
+		Given       *Site
+		Want        string
+		ExpectError bool
+	}{
+		{
+			"valid gzip",
+			&Site{
+				NormalizeAE: NormalizeAEGz,
+			},
+			gunzipCompressionNickname,
+			false,
+		},
+		{
+			"valid brotli",
+			&Site{
+				NormalizeAE: NormalizeAEBrGz,
+			},
+			brotliCompressionNickname,
+			false,
+		},
+		{
+			"invalid encoding",
+			&Site{
+				NormalizeAE: "3-NO-SUCH-NORMALIZE-AE-PARAM",
+			},
+			"",
+			true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			res, err := MapNormalizeAEValueToNickname(tc.Given)
+			if tc.ExpectError {
+				if err == nil {
+					t.Fatalf("expected error, got none")
+				}
+			} else if res != tc.Want {
+				t.Fatalf("FAILED %s: got: %v\nwant: %v", tc.Name, res, tc.Want)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #65 

### このPRはどういう変更を行いますか？

* RequestProtocol, NormalizeAE の文字列表現を定義します
* リクエスト・レスポンスパラメータとして指定可能なenum値と文字列表現との相互変換処理を追加
* 各種文字列表現のconst/varを追加し、他のパッケージ(terraform-provider-sakuracloud, usacloud等)から再利用しやすくします。

### ドキュメントの変更は必要ですか？

不要です。